### PR TITLE
bump CI Python version from 3.9 to 3.11

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -21,7 +21,7 @@ jobs:
     - name: Set up uv 🐍
       uses: astral-sh/setup-uv@v5
       with:
-        python-version: "3.9"
+        python-version: "3.11"
     - name: Install package 📦
       run: uv sync --group test
     - name: Test with pytest 👩‍⚕️


### PR DESCRIPTION
## What does this PR do?

- Updates Python version from 3.9 to 3.11

## Type of change

- [x] Bug fix

## How has this been tested?

-/-

## Checklist

- [ ] Tests pass locally (`uv run pytest tests/`)
- [ ] New tests added for new functionality
- [ ] Documentation updated if needed
